### PR TITLE
Add training config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/learning/configs/mortar.py
+++ b/learning/configs/mortar.py
@@ -1,0 +1,54 @@
+from torch import nn
+from stable_baselines3.common.monitor import Monitor
+from learning.mortar_env import MortarEnv
+
+# Helper to create environments for the mortar simulation
+
+def make_mortar_env():
+    def _init():
+        env = Monitor(MortarEnv())
+        return env
+    return _init
+
+config = {
+    "save": {
+        "save_freq": 20000,
+        "save_model_path": "models_sac_mortar/checkpoints",
+        "name_prefix": "sac_mortar"
+    },
+    "env": {
+        "generater": make_mortar_env,
+        "count": 4,
+        "simulation_config": None
+    },
+    "model": {
+        "policy": "MlpPolicy",
+        "verbose": 1,
+        "learning_rate": 3e-4,
+        "buffer_size": 100_000,
+        "batch_size": 256,
+        "learning_starts": 1000,
+        "train_freq": 1,
+        "gradient_steps": 1,
+        "target_update_interval": 1,
+        "gamma": 0.99,
+        "tau": 0.005,
+        "ent_coef": "auto",
+        "target_entropy": "auto",
+        "use_sde": False,
+        "policy_kwargs": {
+            "net_arch": [256, 256],
+            "activation_fn": nn.ReLU
+        },
+        "tensorboard_log": "logs_sac_mortar/tensorboard"
+    },
+    "checkpoint": {
+        "save_freq": 20000,
+        "save_model_path": "models_sac_mortar/checkpoints",
+        "name_prefix": "sac_mortar"
+    },
+    "train": {
+        "total_timesteps_per_iter": 100_000,
+        "num_iterations": 5
+    }
+}

--- a/learning/configs/no_air_resistance.py
+++ b/learning/configs/no_air_resistance.py
@@ -1,0 +1,45 @@
+from torch import nn
+from learning.learn import make_env
+
+config = {
+    "save": {
+        "save_freq": 20000,
+        "save_model_path": "models_sac/checkpoints/",
+        "name_prefix": "sac_projectile"
+    },
+    "env": {
+        "generater": make_env,
+        "count": 4,
+        "simulation_config": None
+    },
+    "model": {
+        "policy": "MlpPolicy",
+        "verbose": 1,
+        "learning_rate": 3e-4,
+        "buffer_size": 100_000,
+        "batch_size": 256,
+        "learning_starts": 1000,
+        "train_freq": 1,
+        "gradient_steps": 1,
+        "target_update_interval": 1,
+        "gamma": 0.99,
+        "tau": 0.005,
+        "ent_coef": "auto",
+        "target_entropy": "auto",
+        "use_sde": False,
+        "policy_kwargs": {
+            "net_arch": [256, 256],
+            "activation_fn": nn.ReLU
+        },
+        "tensorboard_log": "logs_sac/tensorboard/"
+    },
+    "checkpoint": {
+        "save_freq": 20000,
+        "save_model_path": "models_sac/checkpoints/",
+        "name_prefix": "sac_projectile"
+    },
+    "train": {
+        "total_timesteps_per_iter": 100_000,
+        "num_iterations": 5
+    }
+}

--- a/learning/configs/with_air_resistance.py
+++ b/learning/configs/with_air_resistance.py
@@ -1,0 +1,47 @@
+from torch import nn
+from learning.learn import make_env
+
+config = {
+    "env": {
+        "generater": make_env,
+        "count": 6,
+        "simulation_config": {
+            "apply_air_resistance": True
+        }
+    },
+    "save": {
+        "save_freq": 20000,
+        "save_model_path": "models_sac_with_air_resistance/checkpoints/",
+        "name_prefix": "sac_projectile_with_air_resistance"
+    },
+    "model": {
+        "policy": "MlpPolicy",
+        "verbose": 1,
+        "learning_rate": 3e-4,
+        "buffer_size": 100_000,
+        "batch_size": 256,
+        "learning_starts": 1000,
+        "train_freq": 1,
+        "gradient_steps": 1,
+        "target_update_interval": 1,
+        "gamma": 0.99,
+        "tau": 0.005,
+        "ent_coef": "auto",
+        "target_entropy": "auto",
+        "use_sde": False,
+        "policy_kwargs": {
+            "net_arch": [256, 256],
+            "activation_fn": nn.ReLU
+        },
+        "tensorboard_log": "logs_sac_with_air_resistance/tensorboard/"
+    },
+    "checkpoint": {
+        "save_freq": 10000,
+        "save_model_path": "models_sac_with_air_resistance/checkpoints/",
+        "name_prefix": "sac_projectile_with_air_resistance"
+    },
+    "train": {
+        "total_timesteps_per_iter": 100_000,
+        "num_iterations": 4
+    }
+}


### PR DESCRIPTION
## Summary
- configure .gitignore to avoid committing pycache files
- add reusable configs for baseline SAC, air resistance SAC and mortar SAC models

## Testing
- `pytest -q`
- `PYTHONPATH=. python test/test.py`

------
https://chatgpt.com/codex/tasks/task_e_6870fc562b88832c9120d66cf585e8ce